### PR TITLE
Add user email in error message

### DIFF
--- a/QueueUserInfo.cs
+++ b/QueueUserInfo.cs
@@ -69,7 +69,7 @@ namespace appsvc_fnc_dev_CreateUser_dotnet
 
                     if (isSynced)
                     {
-                        ResponsQueue = $"{Department} already synced";
+                        ResponsQueue = $"{Department} already synced. User email:{EmailWork}";
                         return new BadRequestObjectResult(ResponsQueue);
                     }
 


### PR DESCRIPTION
Adding the user email in the error message to the registration page is able to capture this information for the error message